### PR TITLE
parameterized for GovCloud

### DIFF
--- a/deployment/server-fleet-management-at-scale-inspector.yaml
+++ b/deployment/server-fleet-management-at-scale-inspector.yaml
@@ -185,11 +185,18 @@ Mappings:
       ServiceAccountArn: arn:aws:iam::646659390643:root
 
     us-gov-west-1:
-      CVERulesPackage: NotSupported
-      CISRulesPackage: NotSupported
-      SecurityBestPracticesRulesPackage: NotSupported
-      RuntimeBehaviorRulesPackage: NotSupported
-      ServiceAccountArn: NotSupported
+      CVERulesPackage: arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-4oQgcI4G
+      CISRulesPackage: arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-Ac4CFOuc
+      SecurityBestPracticesRulesPackage: arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-rOTGqe5G
+      RuntimeBehaviorRulesPackage: arn:aws-us-gov:inspector:us-gov-west-1:850862329162:rulespackage/0-JMyjuzoW
+      ServiceAccountArn: arn:aws-us-gov:iam::850862329162:root
+
+    us-gov-east-1:
+      CVERulesPackage: arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-3IFKFuOb
+      CISRulesPackage: arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-pTLCdIww
+      SecurityBestPracticesRulesPackage: arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-vlgEGcVD
+      RuntimeBehaviorRulesPackage: arn:aws-us-gov:inspector:us-gov-east-1:206278770380:rulespackage/0-850TmCFX
+      ServiceAccountArn: arn:aws-us-gov:iam::206278770380:root
 
     us-west-1:
       CVERulesPackage: arn:aws:inspector:us-west-1:166987590008:rulespackage/0-TKgzoVOa
@@ -431,7 +438,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: InspectorAndSsm
           PolicyDocument:

--- a/deployment/server-fleet-management-at-scale.yaml
+++ b/deployment/server-fleet-management-at-scale.yaml
@@ -45,6 +45,12 @@ Metadata:
         Parameters:
           - NotificationEmailAddress
 
+      - Label:
+          default: |
+            Query AWS Systems Manager Parameter Store for the latest AMI IDs.
+        Parameters:
+          - LatestAmazonLinuxAmiId
+          - LatestWindows2012AmiId
     ParameterLabels:
       Environment:
         default: Managed Instances Tag Value
@@ -54,6 +60,12 @@ Metadata:
 
       NotificationEmailAddress:
         default: Notification Email Address
+
+      LatestAmazonLinuxAmiId:
+        default: Amazon Linux 
+
+      LatestWindows2012AmiId:
+        default: Windows 2012
 
 #==================================================
 # Parameters
@@ -95,12 +107,22 @@ Parameters:
       only applies if you launch the template in a region that supports Inspector.)
     Type: String
 
+  LatestAmazonLinuxAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2'
+
+  LatestWindows2012AmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-windows-latest/Windows_Server-2012-R2_RTM-English-64Bit-Base'
+
 #==================================================
 # Conditions
 #==================================================
 Conditions:
 
   CreateFleet: !Equals [!Ref CreateFleet, "Yes"]
+
+  GovCloud: !Equals [!Ref "AWS::Partition", "aws-us-gov"]
 
   #==================================================
   # Source: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
@@ -113,9 +135,12 @@ Conditions:
     - !Equals [!Ref "AWS::Region", "eu-central-1"]
     - !Equals [!Ref "AWS::Region", "eu-west-1"]
     - !Equals [!Ref "AWS::Region", "ap-southeast-2"]
-    - !Equals [!Ref "AWS::Region", "ap-northeast-2"]
-    - !Equals [!Ref "AWS::Region", "ap-northeast-1"]
+    # - !Equals [!Ref "AWS::Region", "ap-northeast-2"]
+    # - !Equals [!Ref "AWS::Region", "ap-northeast-1"]
     - !Equals [!Ref "AWS::Region", "ap-south-1"]
+    # limit of 10 booleans per or condition
+    - !Equals [!Ref "AWS::Region", "us-gov-west-1"]
+    - !Equals [!Ref "AWS::Region", "us-gov-east-1"]
 
 #==================================================
 # Mappings
@@ -175,6 +200,12 @@ Mappings:
     us-west-2:
       UBUNTU1604HVM: ami-4e79ed36
       RHEL75HVM: ami-223f945a
+    us-gov-west-1:
+      UBUNTU1604HVM: ami-1580c474
+      RHEL75HVM: ami-5a740e3b
+    us-gov-east-1:
+      UBUNTU1604HVM: ami-0933d278
+      RHEL75HVM: ami-43d63732
 
   SourceCode:
     General:
@@ -207,7 +238,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole
       Policies:
         - PolicyName: PassRole
           PolicyDocument:
@@ -302,7 +333,7 @@ Resources:
           - kms:*
           Effect: Allow
           Principal:
-            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
           Resource: "*"
         - Sid: ssm-access-policy-statement
           Action:
@@ -429,7 +460,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -495,7 +526,11 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: RegionSupportsInspector
     Properties:
-      TemplateURL: { "Fn::Join": [ "", [ "https://s3.amazonaws.com/", "%%BUCKET_NAME%%", "-", { "Ref": "AWS::Region" } , "/server-fleet-management-at-scale/%%VERSION%%/server-fleet-management-at-scale-inspector.template" ] ] }
+      TemplateURL: 
+        !If
+        - GovCloud
+        - !Sub https://s3.${AWS::Region}.amazonaws.com/%%BUCKET_NAME%%-${AWS::Region}/server-fleet-management-at-scale/%%VERSION%%/server-fleet-management-at-scale-inspector.template
+        - !Sub https://s3.amazonaws.com/%%BUCKET_NAME%%-${AWS::Region}/server-fleet-management-at-scale/%%VERSION%%/server-fleet-management-at-scale-inspector.template
       Parameters:
         Environment: !Ref Environment
         NotificationEmailAddress: !Ref NotificationEmailAddress
@@ -694,7 +729,7 @@ Resources:
               Service: [ec2.amazonaws.com]
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
 
   #==================================================
   # IAM profile to be used by the application instances
@@ -714,7 +749,7 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref InstanceProfile
       ImageId: !FindInMap [ AWSAMIRegionMap, !Ref "AWS::Region", RHEL75HVM ]
-      InstanceType: t2.large
+      InstanceType: t3.large
       NetworkInterfaces:
         - DeleteOnTermination: true
           Description: ENI for RHEL7.5 Sample Fleet instance
@@ -743,7 +778,7 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref InstanceProfile
       ImageId: !FindInMap [ AWSAMIRegionMap, !Ref "AWS::Region", UBUNTU1604HVM ]
-      InstanceType: t2.large
+      InstanceType: t3.large
       NetworkInterfaces:
         - DeleteOnTermination: true
           Description: ENI for Ubuntu 16.04 Sample Fleet instance
@@ -772,8 +807,8 @@ Resources:
     Condition: CreateFleet
     Properties:
       IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !GetAtt LinuxAMIInfo.Id
-      InstanceType: t2.large
+      ImageId: !Ref LatestAmazonLinuxAmiId
+      InstanceType: t3.large
       NetworkInterfaces:
         - DeleteOnTermination: true
           Description: ENI for Amazon Linux Sample Fleet instance
@@ -794,8 +829,8 @@ Resources:
     Condition: CreateFleet
     Properties:
       IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !GetAtt WindowsAMIInfo.Id
-      InstanceType: t2.large
+      ImageId: !Ref LatestWindows2012AmiId
+      InstanceType: t3.large
       NetworkInterfaces:
         - DeleteOnTermination: true
           Description: ENI for Windows 2016 Sample Fleet instance
@@ -810,31 +845,6 @@ Resources:
           Value: !Ref Environment
         - Key: Patch Group
           Value: !Ref Environment
-
-#==================================================
-# AMI of Windows and Linux at Runtime
-#==================================================
-  WindowsAMIInfoFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Code:
-        S3Bucket: !Sub solutions-${AWS::Region}
-        S3Key: "library/amilookup/amilookup-win.zip"
-      Handler: !Sub "amilookup-win.handler"
-      Runtime: nodejs8.10
-      Timeout: 30
-      Role: !GetAtt LambdaExecutionRole.Arn
-
-  LinuxAMIInfoFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Code:
-        S3Bucket: !Sub solutions-${AWS::Region}
-        S3Key: "library/amilookup/amilookup.zip"
-      Handler: !Sub "amilookup.handler"
-      Runtime: nodejs8.10
-      Timeout: 30
-      Role: !GetAtt LambdaExecutionRole.Arn
 
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -859,25 +869,11 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: arn:aws:logs:*:*:*
+            Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
           - Effect: Allow
             Action:
             - ec2:DescribeImages
             Resource: "*"
-
-  WindowsAMIInfo:
-    Type: Custom::WindowsAMIInfo
-    Properties:
-      ServiceToken: !GetAtt WindowsAMIInfoFunction.Arn
-      Region: !Ref "AWS::Region"
-      OSName: !FindInMap [ AWSAMIRegionMap, AMI, WINDOWSSERVER2012 ]
-
-  LinuxAMIInfo:
-    Type: Custom::LinuxAMIInfo
-    Properties:
-      ServiceToken: !GetAtt LinuxAMIInfoFunction.Arn
-      Region: !Ref "AWS::Region"
-      Architecture: "HVM64"
 
 #==================================================
 # Solution Helper
@@ -890,8 +886,8 @@ Resources:
       Description: This function is a CloudFormation custom lambda resource that
         generates UUID for each deployment.
       Code:
-       S3Bucket: !Sub solutions-${AWS::Region}
-       S3Key: library/solution-helper/v3/solution-helper.zip
+        S3Bucket: !Sub solutions-${AWS::Region}
+        S3Key: library/solution-helper/v3/solution-helper.zip
       Runtime: python2.7
       Timeout: 300
 
@@ -916,7 +912,7 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
 
   CreateUniqueID:
     Type: Custom::LoadLambda


### PR DESCRIPTION
- Added ARNs for Rules Packages in us-gov-west-1 and us-gov-east-1
- Added us-gov-west-1 and us-gov-east-1 to condition for Inspector Region support
  - Commented out ap-northeast-1 and ap-northeast-2 from since "Or" condition function is currently limited to 10 booleans
- Modified ARNs to use Pseudo Parameters for Partition
- Added parameters to query AWS Systems Manager Parameter Store for the latest AMI IDs 
  - Deleted the Custom Resources that previously determined the latest AMI IDs
- Added a condition for GovCloud Partition to use in S3 Template URLs
- Added mappings for Ubuntu and RHEL AMI IDs in us-gov-west-1 and us-gov-east-1
- Modified Instance Types to t3 (t2 is unavailable in us-gov-east-1)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
